### PR TITLE
fix(documents): propagate document delete to the shared server copy

### DIFF
--- a/src/components/internal-tools/document-builder/DocumentsListApp.tsx
+++ b/src/components/internal-tools/document-builder/DocumentsListApp.tsx
@@ -5,7 +5,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { useCrm } from '@/components/crm/CrmContext';
-import { syncDocuments, pushDocumentToServer } from '@/lib/document-builder/sync';
+import { syncDocuments, pushDocumentToServer, deleteDocumentFromServer } from '@/lib/document-builder/sync';
 import styles from './list.module.css';
 import ConfirmDialog from '../ConfirmDialog';
 import TemplateChooser from './TemplateChooser';
@@ -49,6 +49,7 @@ export default function DocumentsListApp() {
   const [dialog, setDialog] = useState<Dialog>(null);
   const [chooserOpen, setChooserOpen] = useState(false);
   const [importError, setImportError] = useState('');
+  const [deleteNote, setDeleteNote] = useState('');
   const fileRef = useRef<HTMLInputElement>(null);
 
   // Arriving from the meetings flow: /internal/documents?forOrg=<uuid> means "start a
@@ -173,6 +174,12 @@ export default function DocumentsListApp() {
         </p>
       )}
 
+      {deleteNote && (
+        <p className={styles.importError} role="alert">
+          {deleteNote}
+        </p>
+      )}
+
       <div className={styles.storageBar} title={`${usedPct}% of ~5MB used`}>
         <div className={styles.storageFill} style={{ width: `${usedPct}%` }} data-warn={usedPct >= 80} />
         <span className={styles.storageLabel}>
@@ -258,8 +265,21 @@ export default function DocumentsListApp() {
           danger
           onCancel={() => setDialog(null)}
           onConfirm={() => {
-            deleteDoc(dialog.doc.id);
+            const { id, name } = dialog.doc;
+            // Remove the local editing copy AND the shared server copy. Without the server
+            // delete, syncDocuments re-downloads the row on the next list load and the
+            // document reappears. Local removal is immediate; the server delete is awaited
+            // only to warn if it didn't land (offline/error), in which case it may resurface.
+            deleteDoc(id);
             setDialog(null);
+            setDeleteNote('');
+            void deleteDocumentFromServer(id).then((ok) => {
+              if (!ok) {
+                setDeleteNote(
+                  `“${name}” was removed here, but its shared copy couldn’t be deleted — it may reappear. Try again when you’re back online.`,
+                );
+              }
+            });
           }}
         />
       )}

--- a/src/lib/document-builder/sync.ts
+++ b/src/lib/document-builder/sync.ts
@@ -71,6 +71,28 @@ export async function pushDocumentToServer(doc: BuiltDocument): Promise<boolean>
   }
 }
 
+async function deleteDocument(id: string): Promise<boolean> {
+  const response = await fetch(`/api/crm/documents/${encodeURIComponent(id)}`, {
+    method: 'DELETE',
+  });
+  return response.ok;
+}
+
+/**
+ * Remove a document's shared server copy. Called from the documents list right after the
+ * local removal (deleteDoc): without it, syncDocuments re-downloads the still-present server
+ * row on the next list load and the "deleted" document reappears. Returns whether the server
+ * accepted the delete so the caller can warn when it didn't reach the server (offline/error)
+ * and the document may resurface. Awaitable, but never throws.
+ */
+export async function deleteDocumentFromServer(id: string): Promise<boolean> {
+  try {
+    return await deleteDocument(id);
+  } catch {
+    return false;
+  }
+}
+
 /** Reconcile local and server. Safe to call repeatedly; idempotent. */
 export async function syncDocuments(): Promise<SyncResult> {
   const result: SyncResult = { uploaded: 0, downloaded: 0, failed: 0 };


### PR DESCRIPTION
Deleting a document only removed the localStorage copy; the server row was left in place, so syncDocuments (which runs on every documents-list load and re-downloads any server row missing locally) pulled it straight back — the "deleted" document reappeared. The DELETE /api/crm/documents/[id] endpoint already existed and hard-deletes the row; the client just never called it.

- sync.ts: add deleteDocumentFromServer(id) — DELETE /api/crm/documents/[id], mirroring the CRM entity remove() pattern (best-effort, never throws, returns server acceptance).
- DocumentsListApp: on delete-confirm, remove locally AND server-side; surface a note if the server delete didn't land (offline/error) so the user knows it may resurface.

Presentations/decks are localStorage-only (no server sync), so their delete already worked fully — left untouched.